### PR TITLE
Fix feed import

### DIFF
--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -37,7 +37,14 @@ window.onload = async () => {
           alert("No feeds found");
           return;
         }
-        for (const feed of imported) {
+        for (const {title, feedUrl, siteUrl} of imported) {
+          const feed = {
+            title,
+            feedUrl,
+            siteUrl,
+            parentId: await Settings.getDefaultFolder(),
+            maxItems: 25,
+          };
           await LivemarkStore.add(feed);
         }
         alert(`Successfully imported ${imported.length} feeds.`);


### PR DESCRIPTION
This fixes #32. Without this patch https://github.com/nt1m/livemarks/blob/master/background/background.js#L84 is NaN, because `maxItems` doesn't exist. So no feed items are ever added. In general importing seems sort of buggy, for some period there are a lot of duplicate feed items, probably some concurrent running updates?