### PR TITLE
Avoid unnecessary creation / deletion of bookmarks in `updateLivemark`

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -40,18 +40,38 @@ const LivemarkUpdater = {
     }
   },
   // adds the site url bookmark if it doesn't
-  // exist already
-  async addFeedSiteUrlBookmark(folder, feed) {
-    await browser.bookmarks.create({
-      title: siteBookmarkPrefix + folder.title + siteBookmarkPostfix,
-      url: feed.siteUrl,
-      parentId: folder.id,
-    });
-    await browser.bookmarks.create({
-      type: "separator",
-      title: "",
-      parentId: folder.id,
-    });
+  // exist already. Returns whether or not it modified the child list.
+  async addFeedSiteUrlBookmark(folder, feed, children) {
+    const siteUrlTitle = siteBookmarkPrefix + folder.title + siteBookmarkPostfix;
+    let didChange = false;
+    if (children.length === 0) {
+      await browser.bookmarks.create({
+        title: siteUrlTitle,
+        url: feed.siteUrl,
+        parentId: folder.id,
+      });
+      didChange = true;
+    } else if (children[0].title !== siteUrlTitle ||
+               children[0].url !== feed.siteUrl) {
+      await browser.bookmarks.update(children[0].id, {
+        title: siteUrlTitle,
+        url: feed.siteUrl,
+      });
+      didChange = true;
+    }
+
+    if (children.length <= 1 || children[1].type !== "separator") {
+      // We don't have a separator or it's in the wrong place, just make a new
+      // one. We delete separators found later in the list anyway.
+      await browser.bookmarks.create({
+        parentId: folder.id,
+        title: "",
+        type: "separator",
+        index: 1,
+      });
+      didChange = true;
+    }
+    return didChange;
   },
   async updateLivemark(feed, options) {
     const {
@@ -73,23 +93,64 @@ const LivemarkUpdater = {
       unreadPrefix += " ";
     }
 
-    const children = await browser.bookmarks.getChildren(folder.id);
-    for (const bookmark of children) {
-      await browser.bookmarks.remove(bookmark.id);
-    }
+    // Note: We make an effort to avoid unnecessary churn on bookmark
+    // creation/deletion, as it give firefox sync a hard time:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1499881
+
+    let children = await browser.bookmarks.getChildren(folder.id);
+    let startIndex = 0;
 
     if (feed.siteUrl) {
-      await this.addFeedSiteUrlBookmark(folder, feed);
+      const didChange = await this.addFeedSiteUrlBookmark(folder, feed, children);
+      // Changes should be rare, so just refetch the child list if it changed
+      // rather than attempting to keep it up to date.
+      if (didChange) {
+        children = await browser.bookmarks.getChildren(folder.id);
+      }
+      startIndex = 2;
     }
+
+    // List of children we can overwrite with update.
+    const usableChildren = [];
+
+    for (let i = startIndex; i < children.length; ++i) {
+      // Remove unexpected separators/folders, since update can't change type.
+      const bookmark = children[i];
+      if (bookmark.type !== "bookmark") {
+        await browser.bookmarks.remove(bookmark.id);
+      } else {
+        usableChildren.push(bookmark);
+      }
+    }
+
     const max = Math.min(feed.maxItems, feedData.items.length);
-    for (let i = 0; i < max; i++) {
+    let i = 0;
+    for (; i < max; i++) {
       const item = feedData.items[i];
       const visits = await browser.history.getVisits({"url": item.url});
-      await browser.bookmarks.create({
-        "parentId": folder.id,
-        "title": ((visits.length > 0) ? readPrefix : unreadPrefix) + item.title,
-        "url": item.url,
-      });
+      const title = ((visits.length > 0) ? readPrefix : unreadPrefix) + item.title;
+      if (i < usableChildren.length) {
+        // There's a child in the right place, see if it has the right data,
+        // and update it if not.
+        const child = usableChildren[i];
+        if (child.url !== item.url || child.title !== title) {
+          await browser.bookmarks.update(child.id, {
+            title,
+            url: item.url,
+          });
+        }
+      } else {
+        // Out of children, make a new one.
+        await browser.bookmarks.create({
+          parentId: folder.id,
+          title,
+          url: item.url,
+        });
+      }
+    }
+    // Delete any children we didn't end up needing.
+    for (; i < usableChildren.length; ++i) {
+      await browser.bookmarks.remove(usableChildren[i].id);
     }
     await LivemarkStore.edit(folder.id, {updated: feedData.updated});
   }


### PR DESCRIPTION
This makes an effort to avoid create/delete/update operations where possible, and should fix or at least help with [bug 1499881](https://bugzilla.mozilla.org/show_bug.cgi?id=1499881). (Although I suspect bookmark sync still won't like it...)

It's similar to #37 but simpler and more focused on avoiding the unnecessary create/delete, although it does avoid the update in cases where no change would occur. (Note that the library linked in #37 would still cause a lot of deletion churn because it wouldn't turn separate `add` / `remove` into `update` + `move`).

Anyway, I've tested it manually and it seems to work, and `npm run lint` comes back clean for the code I changed.