### PR TITLE
Basic feed preview support

### DIFF
--- a/contentscripts/detector.js
+++ b/contentscripts/detector.js
@@ -51,8 +51,9 @@ function debugMsg(loglevel, text) {
   }
 }
 
-// See if the current document is a feed document and if so, let
-// the extension know that we should show the subscribe page instead.
+// See if the current document is a feed document and if so, go to the
+// subscribe page instead.
 if (containsFeed(document)) {
-  chrome.runtime.sendMessage({msg: "feedDocument", href: location.href});
+  location.href = chrome.extension.getURL("pages/subscribe/subscribe.html") + "?" +
+                  encodeURIComponent(location.href);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -36,6 +36,9 @@
     "default_title": "Subscribe",
     "default_popup": "popup/popup.html"
   },
-  "permissions": ["storage", "bookmarks", "history", "notifications", "<all_urls>", "tabs", "menus"],
-  "version": "1.5"
+  "permissions": ["storage", "bookmarks", "history", "notifications", "webRequest", "webRequestBlocking", "<all_urls>", "tabs", "menus"],
+  "version": "1.5",
+  "web_accessible_resources": [
+    "pages/subscribe/subscribe.html"
+  ]
 }

--- a/pages/subscribe/subscribe.js
+++ b/pages/subscribe/subscribe.js
@@ -29,11 +29,14 @@ function setPreviewContent(html) {
 * The main function. fetches the feed data.
 */
 async function main() {
-  await LivemarkStore.init();
   const queryString = location.search.substring(1).split("&");
   const feedUrl = decodeURIComponent(queryString[0]);
   try {
-    const feed = await FeedParser.getFeed(feedUrl);
+    const feed = await browser.runtime.sendMessage({
+      msg: "get-feed",
+      feedUrl
+    });
+
     const {title, url: siteUrl, items} = feed;
     if (items.length == 0) {
       setPreviewContent("<main id=\"error\">No feed entries found</main>");
@@ -43,17 +46,13 @@ async function main() {
     document.title = title;
     document.querySelector("#title").textContent = title;
     document.querySelector("#subscribe-button").addEventListener("click", async () => {
-      const folderId = await Settings.getDefaultFolder();
-      await LivemarkStore.add({
+      const folderTitle = await browser.runtime.sendMessage({
+        msg: "subscribe",
         title,
         feedUrl,
-        siteUrl,
-        parentId: folderId,
-        maxItems: 25,
-      });
-
-      const [folderProps] = await browser.bookmarks.get(folderId);
-      alert(`Livemark added to ${folderProps.title},
+        siteUrl
+      })
+      alert(`Livemark added to ${folderTitle},
 please go to the options page to edit it.`);
     });
     setPreviewContent(`<main>${getPreviewHTML(feed)}</main>`);
@@ -61,5 +60,4 @@ please go to the options page to edit it.`);
     console.log(e);
     setPreviewContent("<main id=\"error\">Failed to fetch feed</main>");
   }
-  // document.getElementById('feedUrl').href = 'view-source:' + feedUrl;
 }

--- a/pages/subscribe/subscribe.js
+++ b/pages/subscribe/subscribe.js
@@ -1,8 +1,5 @@
 "use strict";
 
-/* import-globals-from ../../shared/feed-parser.js */
-/* import-globals-from ../../shared/livemark-store.js */
-/* import-globals-from ../../shared/settings.js */
 /* import-globals-from ../reader/reader.js */
 
 window.addEventListener("load", function() {


### PR DESCRIPTION
Started working on #40. I am not even sure `detector.js` has any use. Either the page is served with an  `application/atom+xml` or `application/rss+xml` MIME type and an external application handler dialog "Opening atom.rss ..."  opens or the XML is processed with XSLT and thus the original DOM where we could match "rss" or "feed" elements is gone. 