### PR TITLE
Implement media preview

### DIFF
--- a/pages/reader/reader.css
+++ b/pages/reader/reader.css
@@ -108,3 +108,9 @@ main {
 .item_desc {
   display:block;
 }
+
+.item_media {
+  margin-top: 1em;
+  padding: 0.5em;
+  background-color: #f9f9fa;
+}

--- a/pages/reader/reader.js
+++ b/pages/reader/reader.js
@@ -3,6 +3,39 @@
 /* exported getPreviewHTML */
 /* The HTML computed by this function is appended into a sandboxed iframe */
 
+// Converts a number of bytes to the appropriate unit that results in a
+// number that needs fewer than 4 digits
+function convertByteUnits(bytes) {
+  const units = ["Bytes", "KB", "MB", "GB"];
+  let unitIndex = 0;
+
+  // convert to next unit if it needs 4 digits (after rounding), but only if
+  // we know the name of the next unit
+  while ((bytes >= 999.5) && (unitIndex < units.length - 1)) {
+    bytes /= 1024;
+    unitIndex++;
+  }
+
+  // Get rid of insignificant bits by truncating to 1 or 0 decimal points
+  // 0 -> 0; 1.2 -> 1.2; 12.3 -> 12.3; 123.4 -> 123; 234.5 -> 235
+  bytes = bytes.toFixed((bytes > 0) && (bytes < 100) ? 1 : 0);
+
+  return `${bytes} ${units[unitIndex]}`;
+}
+
+function displayFileName(mediaURL) {
+  try {
+    const url = new URL(mediaURL);
+    const name = url.pathname.substring(url.pathname.lastIndexOf("/") + 1);
+    if (name.length > 3) {
+      return name;
+    }
+  } catch (e) {}
+
+  // Fallback
+  return decodeURIComponent(mediaURL);
+}
+
 function getPreviewHTML({ items }) {
   const container = document.createElement("main");
   for (const item of items) {
@@ -30,6 +63,35 @@ function getPreviewHTML({ items }) {
     itemContainer.appendChild(anchor);
     itemContainer.appendChild(time);
     itemContainer.appendChild(span);
+
+    if (item.media) {
+      const title = document.createElement("strong");
+      title.textContent = "Media";
+
+      const list = document.createElement("ul");
+      for (const media of item.media) {
+        const li = document.createElement("li");
+
+        const file = document.createElement("a");
+        file.textContent = displayFileName(media.url);
+        file.href = media.url;
+        li.append(file);
+
+        if (media.size > 0) {
+          const size = document.createElement("span");
+          size.textContent = ` (${convertByteUnits(media.size)})`;
+          li.append(size);
+        }
+
+        list.append(li);
+      }
+
+      const mediaContainer = document.createElement("div");
+      mediaContainer.className = "item_media";
+      mediaContainer.append(title);
+      mediaContainer.append(list);
+      itemContainer.append(mediaContainer);
+    }
 
     container.appendChild(itemContainer);
   }

--- a/shared/feed-parser.js
+++ b/shared/feed-parser.js
@@ -66,12 +66,35 @@ const FeedParser = {
     }
 
     feed.items = [...doc.querySelectorAll("item")].map(item => {
+      let media;
+
+      const allContent = item.getElementsByTagName("media:content");
+      if (allContent.length) {
+        media = Array.from(allContent, content => {
+          return {
+            url: content.getAttribute("url"),
+            size: content.getAttribute("fileSize"),
+            type: content.getAttribute("type"),
+          };
+        });
+      } else {
+        const enclosure = item.querySelector("enclosure");
+        if (enclosure) {
+          media = [{
+            url: enclosure.getAttribute("url"),
+            size: enclosure.getAttribute("length"),
+            type: enclosure.getAttribute("type"),
+          }];
+        }
+      }
+
       return {
         title: getTextFromElement("title", item),
         url: getTextFromElement("link", item),
         description: getTextFromElement("description", item),
         updated: getTextFromElement("pubDate", item),
-        id: getTextFromElement("guid", item)
+        id: getTextFromElement("guid", item),
+        media
       };
     });
 


### PR DESCRIPTION
Fixes #73. This is just a first pass. Would be nice to directly add some  `<audio>` element so playing podcast is easier.

Supports `<media:content>` from [Media RSS Specification](http://www.rssboard.org/media-rss) and `<enclosure>` https://en.wikipedia.org/wiki/RSS_enclosure

