### PR TITLE
Limit the number of in-flight updates

### DIFF
--- a/shared/feed-parser.js
+++ b/shared/feed-parser.js
@@ -6,16 +6,20 @@ const FeedParser = {
     return new Promise((resolve, reject) => {
       const request = new XMLHttpRequest();
       request.open("GET", url, true);
+      request.timeout = 5000; // time in milliseconds
 
       request.addEventListener("load", (event) => {
         if (request.responseXML) {
           resolve(request.responseXML);
         } else {
-          reject(new Error(`${request.status}: ${request.statusText}`));
+          reject(new Error(`no XML data (${url})`));
         }
       });
       request.addEventListener("error", (event) => {
-        reject(new Error(`${request.status}: ${request.statusText}`));
+        reject(new Error(`${request.status}: ${request.statusText} (${url})`));
+      });
+      request.addEventListener("timeout", (event) => {
+        reject(new Error(`timeout (${url})`));
       });
 
       request.overrideMimeType("text/xml");


### PR DESCRIPTION
I am not sure how much this will help with #85, but at least we won't be trying to update 100 feeds at the same time now.

I also added a timeout to the XHR request, otherwise the request would go on indefinitely in some cases?