### PR TITLE
fix settings_about_description_3 to settings_about_description_support

### DIFF
--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -53,7 +53,7 @@
         <p>
           <span data-i18n-text="settings_about_description_before_foxish"></span><a href="https://github.com/davidhampgonsalves/foxish">Foxish</a><span data-i18n-text="settings_about_description_after_foxish"></span>
         </p>
-        <p data-i18n-text="settings_about_description_3"></p>
+        <p data-i18n-text="settings_about_description_support"></p>
       </div>
       <div>
         <a data-i18n-text="settings_about_donating" href="https://paypal.me/ntimdev" target="_blank" class="button" id="donate-button" type="submit"></a>


### PR DESCRIPTION
settings_about_description_3 in settings.html was left unchanged.
The new messageName for this item is settings_about_description_support.