### PR TITLE
Mark livemark folders read

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -106,6 +106,12 @@
   "settings_prefixes_read": {
     "message": "Read:"
   },
+  "settings_prefixes_feed_folder": {
+    "message": "Enable prefixes on the feed's folders."
+  },
+  "settings_prefixes_parent_folders": {
+    "message": "Enable prefixes on the feed's parent folders recursively."
+  },
   "settings_feedPreview_heading": {
     "message": "Feed preview"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -107,10 +107,10 @@
     "message": "Read:"
   },
   "settings_prefixes_feed_folder": {
-    "message": "Enable prefixes on the feed's folders."
+    "message": "Show on folders when all their items are read/unread"
   },
   "settings_prefixes_parent_folders": {
-    "message": "Enable prefixes on the feed's parent folders recursively."
+    "message": "Show on parent folder when all child folders are read/unread"
   },
   "settings_feedPreview_heading": {
     "message": "Feed preview"

--- a/background/background.js
+++ b/background/background.js
@@ -240,7 +240,7 @@ const LivemarkUpdater = {
 
     // Update the feed folder title prefix if all items have been read
     if (await Settings.getPrefixFeedFolderEnabled()){
-      this.setPrefix(folder, itemsReadCount == max);
+      await this.setPrefix(folder, itemsReadCount == max);
     }
 
     // Update the parent folders' title prefix title if all RSS feeds have been read
@@ -276,7 +276,7 @@ const LivemarkUpdater = {
       }
     }
 
-    this.setPrefix(folder, allRead);
+    await this.setPrefix(folder, allRead);
     this.setParentFoldersPrefix(folder);
   },
   async setPrefix(item, isRead) {

--- a/background/background.js
+++ b/background/background.js
@@ -239,10 +239,14 @@ const LivemarkUpdater = {
     await LivemarkStore.edit(folder.id, {updated: feedData.updated});
 
     // Update the feed folder title prefix if all items have been read
-    this.setPrefix(folder, itemsReadCount == max);
+    if (await Settings.getPrefixFeedFolderEnabled()){
+      this.setPrefix(folder, itemsReadCount == max);
+    }
 
     // Update the parent folders' title prefix title if all RSS feeds have been read
-    this.setParentFoldersPrefix(folder);
+    if (await Settings.getPrefixParentFoldersEnabled()){
+      this.setParentFoldersPrefix(folder);
+    }
 
   },
   async setParentFoldersPrefix(livemark) {

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 2,
   "background": {
     "scripts": [
+      "shared/prefix-utils.js",
       "shared/feed-parser.js",
       "shared/settings.js",
       "shared/livemark-store.js",

--- a/pages/settings/settings.css
+++ b/pages/settings/settings.css
@@ -30,7 +30,16 @@ main > * {
 }
 
 .broken {
-  background-image: linear-gradient(45deg, rgba(252, 166, 166, 0.7) 25%, white 25%, white 50%, rgba(252, 166, 166, 0.7) 50%, rgba(252, 166, 166, 0.7) 75%, white 75%, white 100%);
+  background-image: linear-gradient(
+    45deg,
+    rgba(252, 166, 166, 0.7) 25%,
+    var(--card-background) 25%,
+    var(--card-background) 50%,
+    rgba(252, 166, 166, 0.7) 50%,
+    rgba(252, 166, 166, 0.7) 75%,
+    var(--card-background) 75%,
+    var(--card-background) 100%
+  );
   background-size: 3em 3em;
 }
 

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -43,10 +43,20 @@
       <div class="section">
         <h3 data-i18n-text="settings_prefixes_heading"></h3>
         <p data-i18n-text="settings_prefixes_description"></p>
-        <label data-i18n-text="settings_prefixes_unread"></label>
-        <input class="short" name="unreadPrefix">
-        <label data-i18n-text="settings_prefixes_read"></label>
-        <input class="short" name="readPrefix">
+        <div>
+          <label data-i18n-text="settings_prefixes_unread"></label>
+          <input class="short" name="unreadPrefix">
+          <label data-i18n-text="settings_prefixes_read"></label>
+          <input class="short" name="readPrefix">
+        </div>
+        <div>
+          <input type="checkbox" name="prefixFeedFolder">
+          <label data-i18n-text="settings_prefixes_feed_folder"></label>
+        </div>
+        <div>
+          <input type="checkbox" name="prefixParentFolders">
+          <label data-i18n-text="settings_prefixes_parent_folders"></label>
+        </div>
       </div>
       <div class="section">
         <h3 data-i18n-text="settings_feedPreview_heading"></h3>

--- a/pages/settings/settings.html
+++ b/pages/settings/settings.html
@@ -49,20 +49,23 @@
           <label data-i18n-text="settings_prefixes_read"></label>
           <input class="short" name="readPrefix">
         </div>
+        <br/>
         <div>
-          <input type="checkbox" name="prefixFeedFolder">
-          <label data-i18n-text="settings_prefixes_feed_folder"></label>
-        </div>
-        <div>
-          <input type="checkbox" name="prefixParentFolders">
-          <label data-i18n-text="settings_prefixes_parent_folders"></label>
+          <div class="flex">
+            <input type="checkbox" id="prefixFeedFolder" name="prefixFeedFolder">
+            <label class="grow" for="prefixFeedFolder" data-i18n-text="settings_prefixes_feed_folder"></label>
+          </div>
+          <div class="flex">
+            <input type="checkbox" id="prefixParentFolders" name="prefixParentFolders">
+            <label class="grow" for="prefixParentFolders" data-i18n-text="settings_prefixes_parent_folders"></label>
+          </div>
         </div>
       </div>
       <div class="section">
         <h3 data-i18n-text="settings_feedPreview_heading"></h3>
         <div class="flex">
-          <input type="checkbox" name="feedPreview">
-          <label class="grow" data-i18n-text="settings_feedPreview_description"></label>
+          <input type="checkbox" id="feedPreview" name="feedPreview">
+          <label class="grow" for="feedPreview" data-i18n-text="settings_feedPreview_description"></label>
         </div>
       </div>
       <div class="section">
@@ -148,6 +151,7 @@
   </form>
 
   <script src="/shared/i18n.js"></script>
+  <script src="/shared/prefix-utils.js"></script>
   <script src="/shared/settings.js"></script>
   <script src="/shared/livemark-store.js"></script>
   <script src="/shared/feed-parser.js"></script>

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -104,6 +104,8 @@ async function showSettingsDialog() {
   settingsForm.feedPreview.checked = await Settings.getFeedPreviewEnabled();
   settingsForm.elements["extensionIcon"].value = await Settings.getExtensionIcon();
 
+  settingsForm.prefixParentFolders.disabled = !settingsForm.prefixFeedFolder.checked;
+
   await populateFolderSelector(settingsForm.defaultFolder);
 
   const allFeeds = await LivemarkStore.getAll();
@@ -127,6 +129,9 @@ function initDialogs() {
   settingsForm.addEventListener("change", async (e) => {
     e.preventDefault();
     if (settingsForm.reportValidity()) {
+      settingsForm.prefixParentFolders.checked &= settingsForm.prefixFeedFolder.checked;
+      settingsForm.prefixParentFolders.disabled = !settingsForm.prefixFeedFolder.checked;
+
       await Settings.setPollInterval(settingsForm.pollInterval.value);
       await Settings.setReadPrefix(settingsForm.readPrefix.value);
       await Settings.setUnreadPrefix(settingsForm.unreadPrefix.value);

--- a/pages/settings/settings.js
+++ b/pages/settings/settings.js
@@ -99,6 +99,8 @@ async function showSettingsDialog() {
   settingsForm.pollInterval.value = await Settings.getPollInterval();
   settingsForm.readPrefix.value = await Settings.getReadPrefix();
   settingsForm.unreadPrefix.value = await Settings.getUnreadPrefix();
+  settingsForm.prefixFeedFolder.checked = await Settings.getPrefixFeedFolderEnabled();
+  settingsForm.prefixParentFolders.checked = await Settings.getPrefixParentFoldersEnabled();
   settingsForm.feedPreview.checked = await Settings.getFeedPreviewEnabled();
   settingsForm.elements["extensionIcon"].value = await Settings.getExtensionIcon();
 
@@ -129,6 +131,8 @@ function initDialogs() {
       await Settings.setReadPrefix(settingsForm.readPrefix.value);
       await Settings.setUnreadPrefix(settingsForm.unreadPrefix.value);
       await Settings.setDefaultFolder(settingsForm.defaultFolder.value);
+      await Settings.setPrefixFeedFolderEnabled(settingsForm.prefixFeedFolder.checked);
+      await Settings.setPrefixParentFoldersEnabled(settingsForm.prefixParentFolders.checked);
       await Settings.setFeedPreviewEnabled(settingsForm.feedPreview.checked);
       await Settings.setExtensionIcon(settingsForm.elements["extensionIcon"].value);
     }

--- a/pages/subscribe/subscribe.html
+++ b/pages/subscribe/subscribe.html
@@ -23,6 +23,7 @@
   </main>
   <div id="preview"></div>
   <script src="/shared/i18n.js"></script>
+  <script src="/shared/prefix-utils.js"></script>
   <script src="/shared/livemark-store.js"></script>
   <script src="/shared/settings.js"></script>
   <script src="/shared/feed-parser.js"></script>

--- a/shared/settings.js
+++ b/shared/settings.js
@@ -51,6 +51,22 @@ const Settings = {
     return setSetting("unreadPrefix2", newValue);
   },
 
+  getPrefixFeedFolderEnabled() {
+    return getSetting("prefixFeedFolderEnabled", false);
+  },
+
+  setPrefixFeedFolderEnabled(newValue) {
+    return setSetting("prefixFeedFolderEnabled", newValue);
+  },
+
+  getPrefixParentFoldersEnabled() {
+    return getSetting("prefixParentFoldersEnabled", false);
+  },
+
+  setPrefixParentFoldersEnabled(newValue) {
+    return setSetting("prefixParentFoldersEnabled", newValue);
+  },
+
   getFeedPreviewEnabled() {
     return getSetting("feedPreviewEnabled", true);
   },


### PR DESCRIPTION
This pull requests adds two options in the settings page, of which the first enables livemarks to set the read and unread prefixes on the livemarks folders. This gives the user a quick overview if any new items have been added to the feed. 

The second option enables recursively marking the livemark parent's folder as read. This is very useful if you keep all your livemarks in a single folder on bookmarks toolbar. In a quick glance you'll learn if there new items in any feed!

I have been testing this feature for the past week and I can say I wouldn't want to use this plugin without it anymore!