### PR TITLE
trim the openSiteUrl title

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -89,7 +89,7 @@ const LivemarkUpdater = {
   // adds the site url bookmark if it doesn't
   // exist already. Returns whether or not it modified the child list.
   async addFeedSiteUrlBookmark(folder, feed, children) {
-    const siteUrlTitle = browser.i18n.getMessage("openSiteUrl", folder.title);
+    const siteUrlTitle = browser.i18n.getMessage("openSiteUrl", folder.title.trim());
     let didChange = false;
     if (children.length === 0) {
       await browser.bookmarks.create({


### PR DESCRIPTION
Very useful for the trick using spaces as prefixes to restore the exact appearance of the original live bookmarks.