### PR TITLE
Use first media URL as feed URL fallback (fixes #252)

### DIFF
--- a/shared/feed-parser.js
+++ b/shared/feed-parser.js
@@ -110,10 +110,8 @@ const FeedParser = {
       if (!url) {
         url = getTextFromElement("guid:not([isPermaLink='false'])", item);
       }
-      if (!url) {
-        if (media && media.length) {
-          url = media[0].url;
-        }
+      if (!url && media && media.length) {
+        url = media[0].url;
       }
       if (!url) {
         const guid = getTextFromElement("guid[isPermaLink='false']", item);

--- a/shared/feed-parser.js
+++ b/shared/feed-parser.js
@@ -111,6 +111,11 @@ const FeedParser = {
         url = getTextFromElement("guid:not([isPermaLink='false'])", item);
       }
       if (!url) {
+        if (media && media.length) {
+          url = media[0].url;
+        }
+      }
+      if (!url) {
         const guid = getTextFromElement("guid[isPermaLink='false']", item);
         if (guid) {
           url = "?guid=" + encodeURIComponent(guid);


### PR DESCRIPTION
I see you added a fallback using the <guid> in
40c1c7442517dea823f0ba40ee4c8b5af4bd3609.
That <guid isPermanent=false> should not be treated as a URL, so I think
it makes sense to use it as a last resort.
For this feeds this didn't even work, because siteUrl is null, so the
new URL constructor fails ...