### PR TITLE
Add option to open all unread pages in tabs

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -5,6 +5,9 @@
   "reloadLiveBookmark": {
     "message": "Reload Live Bookmark"
   },
+  "openAllUnreadPages": {
+    "message": "Open all unread pages in tabs"
+  },
   "openSiteUrl": {
     "message": "Open \"$site$\"",
     "placeholders": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -5,6 +5,9 @@
   "reloadLiveBookmark": {
     "message": "Actualiser les entrées"
   },
+  "openAllUnreadPages": {
+    "message": "Ouvrir toutes les pages non lues dans des onglets"
+  },
   "openSiteUrl": {
     "message": "Ouvrir « $site$ »",
     "placeholders": {


### PR DESCRIPTION
I removed the option to mark all pages as read without opening them from my last pull request. I also added a github action to run the linter on every push.