### PR TITLE
Add option to mark all items read

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,6 +8,9 @@
   "openAllUnreadPages": {
     "message": "Open all unread pages"
   },
+  "markAllRead": {
+    "message": "Mark all as read"
+  },
   "openSiteUrl": {
     "message": "Open \"$site$\"",
     "placeholders": {

--- a/background/background.js
+++ b/background/background.js
@@ -346,13 +346,14 @@ const ContextMenu = {
           await createItems();
         }
 
+        const hasUnreadChildren = (await getUnreadChildren(bookmarkId)).length >= 1;
         // Disable "Open all unread pages in tabs" and "Mark all as read" 
         // if all feeds are already read/visited.
         browser.menus.update(this.openUnreadItemId, {
-          enabled: (await getUnreadChildren(bookmarkId)).length >= 1
+          enabled: hasUnreadChildren
         });
         browser.menus.update(this.markAllReadItemId, {
-          enabled: (await getUnreadChildren(bookmarkId)).length >= 1
+          enabled: hasUnreadChildren
         });
       }
       await browser.menus.refresh();

--- a/background/background.js
+++ b/background/background.js
@@ -323,6 +323,17 @@ const ContextMenu = {
           }
         }
       });
+
+      this.markAllReadItemId = await browser.menus.create({
+        contexts: ["bookmark"],
+        title: browser.i18n.getMessage("markAllRead"),
+        async onclick({bookmarkId}) {
+          const unreadBookmarks = await getUnreadChildren(bookmarkId);
+          for (let bookmark of unreadBookmarks) {
+            browser.history.addUrl({url: bookmark.url});
+          }
+        }
+      });
     };
 
     browser.menus.onShown.addListener(async ({bookmarkId}) => {
@@ -335,9 +346,12 @@ const ContextMenu = {
           await createItems();
         }
 
-        // Disable "Open all unread pages in tabs" if all feeds are already
-        // read/visited.
+        // Disable "Open all unread pages in tabs" and "Mark all as read" 
+        // if all feeds are already read/visited.
         browser.menus.update(this.openUnreadItemId, {
+          enabled: (await getUnreadChildren(bookmarkId)).length >= 1
+        });
+        browser.menus.update(this.markAllReadItemId, {
           enabled: (await getUnreadChildren(bookmarkId)).length >= 1
         });
       }


### PR DESCRIPTION
Since it was inconvenient to have to open each page in order to mark them read I've added a context menu item to mark items as read.

Unfortunately I wasn't able to add all of the corresponding locales entries for it as I do not speak most of those languages. It works fine in English.