### PR TITLE
Revert "#342 #372 - Try to prevent caching of request"

### DIFF
--- a/shared/feed-parser.js
+++ b/shared/feed-parser.js
@@ -6,8 +6,6 @@ const FeedParser = {
     return new Promise((resolve, reject) => {
       const request = new XMLHttpRequest();
       request.open("GET", url, true);
-      // Try to prevent caching.
-      request.setRequestHeader("Cache-Control", "no-store, max-age=0");
       request.timeout = 10000; // time in milliseconds
 
       request.addEventListener("load", (event) => {


### PR DESCRIPTION
This reverts commit a5e38c43a24373cb893f2d5b23a6135b50a65f75.

It's not entirely clear looking at the history, but it seems this was added to fix a suspected caching problem in #342. The RSS feed in that task doesn't exist any more, but looking at the rest of the site at least as it exists today -- it's not a problem with Firefox/Livemarks, it's a problem with the site sending broken `Cache-Control` headers! They are saying their response can be cached for up to a year, which is obviously wrong for a news site.

But that is a problem with the site, not with Firefox/Livemarks. We really should not be ignoring *the correct caching headers for every single other RSS feed on the internet* to solve one broken site. In particular, since the default refresh interval for Livemarks is 5 minutes, this causes us to force-load all of the RSS feeds every 5 minutes, which tbh is a bit abusive.

This bad behaviour on the part of RSS readers has been called out a few times, most recently https://rachelbythebay.com/w/2023/01/18/http/ -- let's not be one of the bad ones, especially just to fix a single site whose RSS feed does not exist any more anyway.