### PR TITLE
RTL languages support in reader

### DIFF
--- a/pages/reader/reader.js
+++ b/pages/reader/reader.js
@@ -45,6 +45,7 @@ function getPreviewHTML({ items }) {
   for (const item of items) {
     const itemContainer = document.createElement("div");
     itemContainer.classList = "item";
+    itemContainer.setAttribute("dir", "auto");
 
     const anchor = item.url ? document.createElement("a") :
       document.createElement("strong");

--- a/pages/reader/reader.js
+++ b/pages/reader/reader.js
@@ -45,7 +45,7 @@ function getPreviewHTML({ items }) {
   for (const item of items) {
     const itemContainer = document.createElement("div");
     itemContainer.classList = "item";
-    itemContainer.setAttribute("dir", "auto");
+    itemContainer.dir = "auto";
 
     const anchor = item.url ? document.createElement("a") :
       document.createElement("strong");


### PR DESCRIPTION
The text direction for RTL languages is wrong in reader view. 

The `dir=auto` attribute will solve this for most cases, for items with a title that starts with RTL language.

Current status:
![image](https://github.com/user-attachments/assets/76f9a9a5-d23c-461e-9962-a4a1fd55b16a)

Desirable status:
![image](https://github.com/user-attachments/assets/8fc7e2f7-dc3e-4762-8e81-1852f27ff44f)
