### PR TITLE
fix: Tab Stash extension compatibility

### DIFF
--- a/background/background.js
+++ b/background/background.js
@@ -253,7 +253,7 @@ const LivemarkUpdater = {
       return;
     }
 
-    // Tab Stasher extension compatibility
+    // Tab Stash extension compatibility
     if (folder.title === "Tab Stash" && folder.parentId === "unfiled_____") {
       return;
     }


### PR DESCRIPTION
Avoids changing the parent folder's title prefix if it's Tab Stash's root folder