### PR TITLE
Make address bar icon visible in dark mode

### DIFF
--- a/icons/feed.svg
+++ b/icons/feed.svg
@@ -2,5 +2,12 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <path fill="context-fill #0c0c0d" fill-opacity="context-fill-opacity 0.6" d="M3.5 10A2.5 2.5 0 1 0 6 12.5 2.5 2.5 0 0 0 3.5 10zM2 1a1 1 0 0 0 0 2 10.883 10.883 0 0 1 11 11 1 1 0 0 0 2 0A12.862 12.862 0 0 0 2 1zm0 4a1 1 0 0 0 0 2 6.926 6.926 0 0 1 7 7 1 1 0 0 0 2 0 8.9 8.9 0 0 0-9-9z"/>
+  <style>
+    #icon-fill { fill: black; }
+
+    @media (prefers-color-scheme: dark) {
+      #icon-fill { fill: white; }
+    }
+  </style>
+  <path id="icon-fill" fill-opacity="context-fill-opacity 0.6" d="M3.5 10A2.5 2.5 0 1 0 6 12.5 2.5 2.5 0 0 0 3.5 10zM2 1a1 1 0 0 0 0 2 10.883 10.883 0 0 1 11 11 1 1 0 0 0 2 0A12.862 12.862 0 0 0 2 1zm0 4a1 1 0 0 0 0 2 6.926 6.926 0 0 1 7 7 1 1 0 0 0 2 0 8.9 8.9 0 0 0-9-9z"/>
 </svg>


### PR DESCRIPTION
## Issue 
In Firefox 149 Nightly (or Firefox 152 Stable, released 2026-06-17) the automatic address bar icon light and dark mode was disabled. Without this, the icon is currently rendered black, even in dark mode Firefox:

<img width="99" height="50" alt="grafik" src="https://github.com/user-attachments/assets/23e4000f-f3d1-4e56-9d55-f8347fd37169" />


## Solution
This PR fixes that by adding the recommended `prefers-color-scheme` CSS media query to the SVG styles.

<img width="99" height="50" alt="grafik" src="https://github.com/user-attachments/assets/369ecc1f-4cf8-45d7-8ba8-1d23ff94ca84" />


## Sources
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Page_actions#icons
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#default_icon
- https://github.com/mdn/webextensions-examples/blob/main/themed-icons/prefers-color-scheme-icon.svg
- https://bugzilla.mozilla.org/show_bug.cgi?id=2016509
- https://github.com/mozilla-firefox/firefox/commit/aeb4413e3d101e74f416b5d5853ca2adc726aa22
- [https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/149#changes_for_add-on_developers](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/149#changes_for_add-on_developers:~:text=will%20be%20deactivated%20in%20other%20Firefox%20editions%20from%20version%20152)

### Try it out:
- about:config → `extensions.webextensions.pageActionIconDarkModeFilter.enabled`